### PR TITLE
Nginx: Fix centos upstart script

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Opscode, Inc.'
 maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs and configures nginx'
-version           '2.0.5'
+version           '2.1.0'
 
 recipe 'nginx',         'Installs nginx package and sets up configuration with Debian apache style with sites-enabled/sites-available'
 recipe 'nginx::source', 'Installs nginx from source and sets up configuration with Debian apache style with sites-enabled/sites-available'

--- a/templates/centos/nginx-upstart.conf.erb
+++ b/templates/centos/nginx-upstart.conf.erb
@@ -1,0 +1,40 @@
+# nginx
+
+description "nginx http daemon"
+
+start on runlevel [<%= node['nginx']['upstart']['runlevels'] %>]
+stop on runlevel [!<%= node['nginx']['upstart']['runlevels'] %>]
+
+env DAEMON=<%= node['nginx']['binary'] %>
+env PID=<%= node['nginx']['pid'] %>
+env CONFIG=<%= node['nginx']['source']['conf_path'] %>
+
+respawn
+<% if node['nginx']['upstart']['respawn_limit'] %>
+respawn limit <%= node['nginx']['upstart']['respawn_limit'] %>
+<% end %>
+
+pre-start script
+  ${DAEMON} -t
+  if [ $? -ne 0 ]; then
+    exit $?
+  fi
+end script
+
+<% unless node['nginx']['upstart']['foreground'] %>
+expect fork
+<% else %>
+console output
+<% end %>
+
+exec ${DAEMON} -c "${CONFIG}"
+
+<% if node.recipe?('nginx::passenger') and not node['nginx']['upstart']['foreground'] %>
+# classic example of why pidfiles should have gone away
+# with the advent of fork().  we missed that bus a long
+# time ago so hack around it.
+post-stop script
+  start-stop-daemon --stop --pidfile ${PID} --name nginx --exec ${DAEMON} --signal QUIT
+end script
+<% end %>
+


### PR DESCRIPTION
@tom-weiss-github @shridharsheth @johnshaw 

Centos doesn't emit the local filesystem/network up signal, so just rely
on the runlevel to start nginx

DEB-1427
